### PR TITLE
Event details action sheet

### DIFF
--- a/ForgetMeNot/Controllers/EventDetailViewController.swift
+++ b/ForgetMeNot/Controllers/EventDetailViewController.swift
@@ -22,7 +22,6 @@ class EventDetailViewController: UITableViewController {
     let eventsDatabase = EventDatabase()
     var event: Event?
     
-    
     // MARK: - ViewDidLoad
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/ForgetMeNot/Controllers/EventDetailViewController.swift
+++ b/ForgetMeNot/Controllers/EventDetailViewController.swift
@@ -9,8 +9,6 @@
 import UIKit
 
 class EventDetailViewController: UITableViewController {
-
-    
     
     // MARK: - Outlets
     @IBOutlet weak var titleLabel: UILabel!
@@ -33,7 +31,6 @@ class EventDetailViewController: UITableViewController {
     }
     
     // MARK: - Methods
-    
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
     }
@@ -88,7 +85,6 @@ class EventDetailViewController: UITableViewController {
     }
     
     // MARK: - Actions
-    
     @IBAction func haveGiftYesButton(_ sender: UIButton) {
         updateHaveGift(haveGift: true)
         setButtonColors()
@@ -101,7 +97,6 @@ class EventDetailViewController: UITableViewController {
     }
     
     // MARK: - Action Sheet
-    
     @objc func showActionSheet() {
         
         let actionSheet = UIAlertController(title: "What are you gonna do about it?", message: nil, preferredStyle: .actionSheet)
@@ -109,7 +104,7 @@ class EventDetailViewController: UITableViewController {
         let cancel = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
         
         let remindAgain = UIAlertAction(title: "Remind Me Later", style: .default) { action in
-            // does anything happen here?
+            // nothing happens here yet - it basically is another way of saying "cancel"
         }
         
         let needGift = UIAlertAction(title: "Find A Gift", style: .default) { action in

--- a/ForgetMeNot/Controllers/EventDetailViewController.swift
+++ b/ForgetMeNot/Controllers/EventDetailViewController.swift
@@ -22,6 +22,7 @@ class EventDetailViewController: UITableViewController {
     
     // MARK: - Properties
     let eventsDatabase = EventDatabase()
+    var event: Event?
     
     
     // MARK: - ViewDidLoad
@@ -37,16 +38,26 @@ class EventDetailViewController: UITableViewController {
     }
     
     func getEvent() -> Event {
-        return eventsDatabase.events[0]
+        return eventsDatabase.events[2]
     }
     
     func displayEventData() {
-        let event = getEvent()
-        titleLabel.text = event.eventTitle
-        dateLabel.text = event.dateOfEventString
-        haveGiftLabel.text = "Do you have a gift for \(event.giftRecipient)?"
-        notesView.text = event.eventNotes
-        if event.haveGift == false {
+        event = getEvent()
+        
+        guard let titleText = event?.eventTitle else { return }
+        titleLabel.text = titleText
+        
+        guard let dateText = event?.dateOfEventString else { return }
+        dateLabel.text = dateText
+        
+        guard let recipient = event?.giftRecipient else { return }
+        haveGiftLabel.text = "Do you have a gift for \(recipient)?"
+        
+        guard let notesText = event?.eventNotes else { return }
+        notesView.text = notesText
+        
+        guard let haveGiftValue = event?.haveGift else { return }
+        if haveGiftValue == false {
             noButton.backgroundColor = UIColor.blue
             noButton.setTitleColor(UIColor.white, for: .normal)
         }

--- a/ForgetMeNot/Controllers/EventDetailViewController.swift
+++ b/ForgetMeNot/Controllers/EventDetailViewController.swift
@@ -29,6 +29,7 @@ class EventDetailViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         displayEventData()
+        setButtonColors()
     }
     
     // MARK: - Methods
@@ -55,16 +56,6 @@ class EventDetailViewController: UITableViewController {
         
         guard let notesText = event?.eventNotes else { return }
         notesView.text = notesText
-        
-        guard let haveGiftValue = event?.haveGift else { return }
-        if haveGiftValue == false {
-            noButton.backgroundColor = UIColor.blue
-            noButton.setTitleColor(UIColor.white, for: .normal)
-        }
-        else {
-            yesButton.backgroundColor = UIColor.blue
-            yesButton.setTitleColor(UIColor.white, for: .normal)
-        }
     }
     
     func getRandomGift() -> URL? {
@@ -75,12 +66,37 @@ class EventDetailViewController: UITableViewController {
         return url
     }
     
+    func updateHaveGift(haveGift: Bool) {
+        guard let eventToUpdate = event else { return }
+        eventToUpdate.haveGift = haveGift
+    }
+    
+    func setButtonColors() {
+        guard let haveGiftValue = event?.haveGift else { return }
+        if haveGiftValue == false {
+            noButton.backgroundColor = UIColor.blue
+            noButton.setTitleColor(UIColor.white, for: .normal)
+            yesButton.backgroundColor = UIColor.white
+            yesButton.setTitleColor(UIColor.blue, for: .normal)
+        }
+        else {
+            yesButton.backgroundColor = UIColor.blue
+            yesButton.setTitleColor(UIColor.white, for: .normal)
+            noButton.backgroundColor = UIColor.white
+            noButton.setTitleColor(UIColor.blue, for: .normal)
+        }
+    }
+    
     // MARK: - Actions
     
     @IBAction func haveGiftYesButton(_ sender: UIButton) {
+        updateHaveGift(haveGift: true)
+        setButtonColors()
     }
     
     @IBAction func haveGiftNoButton(_ sender: UIButton) {
+        updateHaveGift(haveGift: false)
+        setButtonColors()
         showActionSheet()
     }
     

--- a/ForgetMeNot/Controllers/EventDetailViewController.swift
+++ b/ForgetMeNot/Controllers/EventDetailViewController.swift
@@ -20,7 +20,7 @@ class EventDetailViewController: UITableViewController {
     
     
     // MARK: - Properties
-    
+    let eventsDatabase = EventDatabase()
     
     
     // MARK: - ViewDidLoad
@@ -32,6 +32,10 @@ class EventDetailViewController: UITableViewController {
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
+    }
+    
+    func getEvent() -> Event {
+        return eventsDatabase.events[0]
     }
     
     func getRandomGift() -> URL? {

--- a/ForgetMeNot/Controllers/EventDetailViewController.swift
+++ b/ForgetMeNot/Controllers/EventDetailViewController.swift
@@ -17,7 +17,8 @@ class EventDetailViewController: UITableViewController {
     @IBOutlet weak var dateLabel: UILabel!
     @IBOutlet weak var haveGiftLabel: UILabel!
     @IBOutlet weak var notesView: UITextView!
-    
+    @IBOutlet weak var noButton: UIButton!
+    @IBOutlet weak var yesButton: UIButton!
     
     // MARK: - Properties
     let eventsDatabase = EventDatabase()
@@ -26,6 +27,7 @@ class EventDetailViewController: UITableViewController {
     // MARK: - ViewDidLoad
     override func viewDidLoad() {
         super.viewDidLoad()
+        displayEventData()
     }
     
     // MARK: - Methods
@@ -36,6 +38,22 @@ class EventDetailViewController: UITableViewController {
     
     func getEvent() -> Event {
         return eventsDatabase.events[0]
+    }
+    
+    func displayEventData() {
+        let event = getEvent()
+        titleLabel.text = event.eventTitle
+        dateLabel.text = event.dateOfEventString
+        haveGiftLabel.text = "Do you have a gift for \(event.giftRecipient)?"
+        notesView.text = event.eventNotes
+        if event.haveGift == false {
+            noButton.backgroundColor = UIColor.blue
+            noButton.setTitleColor(UIColor.white, for: .normal)
+        }
+        else {
+            yesButton.backgroundColor = UIColor.blue
+            yesButton.setTitleColor(UIColor.white, for: .normal)
+        }
     }
     
     func getRandomGift() -> URL? {

--- a/ForgetMeNot/Storyboard/EventDetail.storyboard
+++ b/ForgetMeNot/Storyboard/EventDetail.storyboard
@@ -152,8 +152,10 @@
                     <connections>
                         <outlet property="dateLabel" destination="nSM-k9-PuL" id="yOj-al-tdb"/>
                         <outlet property="haveGiftLabel" destination="dn6-yw-8Z8" id="6Rw-rc-Oen"/>
+                        <outlet property="noButton" destination="hT7-F6-zdp" id="VS1-qc-gUD"/>
                         <outlet property="notesView" destination="n7Y-V3-VJo" id="m45-xn-LaX"/>
                         <outlet property="titleLabel" destination="vX5-p1-ZfX" id="rba-fq-5nI"/>
+                        <outlet property="yesButton" destination="8B0-KC-mCZ" id="fHD-rh-w2d"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="J75-mA-5KP" userLabel="First Responder" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
## Reason ✨
Trello Card: [Event Details: Action Sheet](https://trello.com/c/C0713Z9W)

## What I did ✅
- Displayed an actual event from our database on the detail view! (Always the same event for now)
- Conditionally set the button colors based on whether user has a gift for this event or not yet (these button colors are temporary and will change when we have a style guide to apply)
- Update the event's `haveGift` Boolean value based on button press
- **Note**: "Remind me later" in action list doesn't really do anything except dismiss the action list. It may not ever do anything else unless we add some fancier functionality to the app.

## How I did it 🌀
- A few new methods in EventDetailViewController: `setButtonColors()` and `updateHaveGift()`

## How you can test it 🔬
- Check out the detail screen and try pressing the "Yes" or "Not Yet" buttons
- "Yes" should highlight the "Yes" button
- "No" should highlight the "Not Yet" button (or keep it highlighted), and show our action list

## Screenshots 📸
![simulator screen shot - iphone xr - 2018-09-25 at 16 25 02](https://user-images.githubusercontent.com/5642098/46040926-97186b00-c0df-11e8-8804-9e81c998a0ad.png)
![simulator screen shot - iphone xr - 2018-09-25 at 16 25 04](https://user-images.githubusercontent.com/5642098/46040930-997ac500-c0df-11e8-9748-3099fc884545.png)
