### PR TITLE
Display event details

### DIFF
--- a/ForgetMeNot/Controllers/EventDetailViewController.swift
+++ b/ForgetMeNot/Controllers/EventDetailViewController.swift
@@ -35,13 +35,7 @@ class EventDetailViewController: UITableViewController {
         tableView.deselectRow(at: indexPath, animated: true)
     }
     
-    func getEvent() -> Event {
-        return eventsDatabase.events[2]
-    }
-    
     func displayEventData() {
-        event = getEvent()
-        
         guard let titleText = event?.eventTitle else { return }
         titleLabel.text = titleText
         

--- a/ForgetMeNot/Storyboard/Base.lproj/Main.storyboard
+++ b/ForgetMeNot/Storyboard/Base.lproj/Main.storyboard
@@ -43,7 +43,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                         <connections>
-                                            <segue destination="J71-jx-iFO" kind="show" id="KmF-T2-93I"/>
+                                            <segue destination="J71-jx-iFO" kind="show" identifier="EventDetail" id="KmF-T2-93I"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>


### PR DESCRIPTION
## Reason ✨
Trello Card: [Event Details: Display Details/Segue](https://trello.com/c/15mtbrYI)

## What I did ✅
- Got index of selected cell on tap
- Displayed selected event's details on Detail View

## How you can test it 🔬
- Tap on an event on the home screen
- You should see that event's details populate the next screen