### PR TITLE
deselecting row as soon as it's selected

### DIFF
--- a/ForgetMeNot/Controllers/HomeViewController.swift
+++ b/ForgetMeNot/Controllers/HomeViewController.swift
@@ -51,6 +51,10 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
         return indexPath
     }
     
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
+    
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == SegueIdentifier.addEventSegueIdentifier.rawValue {
             guard let addEventViewController = segue.destination as? AddEventViewController else { return }


### PR DESCRIPTION
## Reason ✨
Trello Card: [Home: Deselect Cell](https://trello.com/c/5cGsFSXy)

## What I did ✅
- Deselected cells as soon as they're selected, so they don't stay highlighted when you come back to the view.

## How I did it 🌀
- Called `tableView.deselectRow` as soon as a row is selected in `didSelectRowAt`

## How you can test it 🔬
- Click on a cell in the home view. When you come back to the home view, that cell won't stay highlighted like it used to.
