### PR TITLE
Home order by date

### DIFF
--- a/ForgetMeNot/Controllers/HomeViewController.swift
+++ b/ForgetMeNot/Controllers/HomeViewController.swift
@@ -70,6 +70,12 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
         for event in eventDatabase.events {
             events.append(event)
         }
+        events = sortEvents(array: events)
+    }
+    
+    func sortEvents(array: [Event]) -> [Event] {
+        let sortedEvents = array.sorted(by: { $0.dateOfEvent < $1.dateOfEvent } )
+        return sortedEvents
     }
     
     func getTimeIntervalString(event: Event) -> String {

--- a/ForgetMeNot/Controllers/HomeViewController.swift
+++ b/ForgetMeNot/Controllers/HomeViewController.swift
@@ -127,7 +127,6 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
 
     func displayCurrentDate() {
-
         dateLabel.text = "Today is \(formattedDate())"
     }
 
@@ -164,6 +163,8 @@ extension HomeViewController {
             let decoder = PropertyListDecoder()
             do {
                 events = try decoder.decode([Event].self, from: data)
+                events = sortEvents(array: events)
+                events = limitToFiveEvents(array: events)
             } catch {
                 print("Error decoding item array!")
             }

--- a/ForgetMeNot/Controllers/HomeViewController.swift
+++ b/ForgetMeNot/Controllers/HomeViewController.swift
@@ -90,6 +90,7 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
 
     func limitToFiveEvents(array: [Event]) -> [Event] {
         var fiveSoonestEvents: [Event] = []
+        if events.count < 5 { return events }
         for event in events[0...4] {
             fiveSoonestEvents.append(event)
         }

--- a/ForgetMeNot/Controllers/HomeViewController.swift
+++ b/ForgetMeNot/Controllers/HomeViewController.swift
@@ -23,8 +23,11 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
     override func viewDidLoad() {
         super.viewDidLoad()
         displayCurrentDate()
-        if dataFileExists() { loadEvents() }
-        else { populateData() }
+        if dataFileExists() {
+            loadEvents()
+        } else {
+            populateData()
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -85,7 +88,9 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
 
     func limitToFiveEvents(array: [Event]) -> [Event] {
         var fiveSoonestEvents: [Event] = []
-        if events.count < 5 { return events }
+        if array.count < 5 {
+            return array
+        }
         for event in events[0...4] {
             fiveSoonestEvents.append(event)
         }

--- a/ForgetMeNot/Controllers/HomeViewController.swift
+++ b/ForgetMeNot/Controllers/HomeViewController.swift
@@ -23,8 +23,8 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
     override func viewDidLoad() {
         super.viewDidLoad()
         displayCurrentDate()
-        populateData()
-        loadEvents()
+        if dataFileExists() { loadEvents() }
+        else { populateData() }
 
         // shows usually hidden folders
         print("🌸 Document folder is \(documentsDirectory())")
@@ -170,8 +170,14 @@ extension HomeViewController {
             }
         }
     }
+    
+    func dataFileExists() -> Bool {
+        let fileManager = FileManager()
+        let filePath = dataFilePath().path
+        
+        return fileManager.fileExists(atPath: filePath)
+    }
 }
-
 
 
 extension HomeViewController: AddEventViewControllerDelegate {

--- a/ForgetMeNot/Controllers/HomeViewController.swift
+++ b/ForgetMeNot/Controllers/HomeViewController.swift
@@ -16,6 +16,7 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
     
     // MARK: - Properties
     var events: [Event] = []
+    var fiveSoonestEvents: [Event] = []
     var selectedEventIndex = 0
     
     // MARK: - Override Methods
@@ -73,11 +74,21 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
             }
         }
         events = sortEvents(array: events)
+        events = limitToFiveEvents(array: events)
     }
     
     func sortEvents(array: [Event]) -> [Event] {
-        let sortedEvents = array.sorted(by: { $0.dateOfEvent < $1.dateOfEvent } )
+        var sortedEvents: [Event] = []
+        sortedEvents = array.sorted(by: { $0.dateOfEvent < $1.dateOfEvent } )
         return sortedEvents
+    }
+    
+    func limitToFiveEvents(array: [Event]) -> [Event] {
+        var fiveSoonestEvents: [Event] = []
+        for event in events[0...4] {
+            fiveSoonestEvents.append(event)
+        }
+        return fiveSoonestEvents
     }
     
     func getTimeIntervalString(event: Event) -> String {
@@ -152,12 +163,10 @@ extension HomeViewController: AddEventViewControllerDelegate {
         }
     
     func addEventViewController(_ controller: AddEventViewController, didFinishAdding item: Event) {
-        let newRowIndex = events.count
         events.append(item)
-        print(events)
-        
-        let indexPath = IndexPath(row: newRowIndex, section: 0)
-        tableView.insertRows(at: [indexPath], with: .automatic)
+        events = sortEvents(array: events)
+        events = limitToFiveEvents(array: events)
+        tableView.reloadData()
         
         navigationController?.popViewController(animated: true)
         

--- a/ForgetMeNot/Controllers/HomeViewController.swift
+++ b/ForgetMeNot/Controllers/HomeViewController.swift
@@ -25,10 +25,6 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
         displayCurrentDate()
         if dataFileExists() { loadEvents() }
         else { populateData() }
-
-        // shows usually hidden folders
-        print("🌸 Document folder is \(documentsDirectory())")
-        print("🌸 Data file path is \(dataFilePath())")
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -78,8 +74,7 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
                 events.append(event)
             }
         }
-        events = sortEvents(array: events)
-        events = limitToFiveEvents(array: events)
+        events = sortAndLimitEvents(events: events)
     }
 
     func sortEvents(array: [Event]) -> [Event] {
@@ -95,6 +90,12 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
             fiveSoonestEvents.append(event)
         }
         return fiveSoonestEvents
+    }
+    
+    func sortAndLimitEvents(events: [Event]) -> [Event] {
+        let sortedEvents = sortEvents(array: events)
+        let sortedAndLimited = limitToFiveEvents(array: sortedEvents)
+        return sortedAndLimited
     }
 
     func getTimeIntervalString(event: Event) -> String {
@@ -163,8 +164,7 @@ extension HomeViewController {
             let decoder = PropertyListDecoder()
             do {
                 events = try decoder.decode([Event].self, from: data)
-                events = sortEvents(array: events)
-                events = limitToFiveEvents(array: events)
+                events = sortAndLimitEvents(events: events)
             } catch {
                 print("Error decoding item array!")
             }
@@ -188,8 +188,7 @@ extension HomeViewController: AddEventViewControllerDelegate {
 
     func addEventViewController(_ controller: AddEventViewController, didFinishAdding item: Event) {
         events.append(item)
-        events = sortEvents(array: events)
-        events = limitToFiveEvents(array: events)
+        events = sortAndLimitEvents(events: events)
         tableView.reloadData()
         saveEvents()
         navigationController?.popViewController(animated: true)

--- a/ForgetMeNot/Controllers/HomeViewController.swift
+++ b/ForgetMeNot/Controllers/HomeViewController.swift
@@ -68,7 +68,9 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
     func populateData() {
         let eventDatabase = EventDatabase()
         for event in eventDatabase.events {
-            events.append(event)
+            if event.dateOfEvent > Date() {
+                events.append(event)
+            }
         }
         events = sortEvents(array: events)
     }
@@ -146,12 +148,10 @@ extension HomeViewController {
 extension HomeViewController: AddEventViewControllerDelegate {
 
     func addEventViewControllerDidCancel(_ controller: AddEventViewController) {
-        //print("Do some stuff")
         navigationController?.popViewController(animated: true)
         }
     
     func addEventViewController(_ controller: AddEventViewController, didFinishAdding item: Event) {
-        //print("Do some more stuff")
         let newRowIndex = events.count
         events.append(item)
         print(events)
@@ -160,7 +160,6 @@ extension HomeViewController: AddEventViewControllerDelegate {
         tableView.insertRows(at: [indexPath], with: .automatic)
         
         navigationController?.popViewController(animated: true)
-        
         
         //need to create a save function and call that method here if doing persistence
         

--- a/ForgetMeNot/Model/EventDatabase.swift
+++ b/ForgetMeNot/Model/EventDatabase.swift
@@ -9,10 +9,8 @@
 import Foundation
 
 class EventDatabase {
-    var events = [Event(eventTitle: "Christmas", giftRecipient: "Bella", dateOfEventString: "12/25/2018", haveGift: false, eventNotes: "notes"),
-                  Event(eventTitle: "Kyubei's 7th Birthday!", giftRecipient: "Kyubei", dateOfEventString: "04/25/2019", haveGift: false, eventNotes: "My baby..."),
-                  Event(eventTitle: "Mom's birthday", giftRecipient: "Mom", dateOfEventString: "05/25/2019", haveGift: false, eventNotes: "Don't forget!"),
-                  Event(eventTitle: "Mom's birthday", giftRecipient: "Mom", dateOfEventString: "03/31/2019", haveGift: false, eventNotes: "Don't forget!"),
-                  Event(eventTitle: "LabsConf", giftRecipient: "Mom", dateOfEventString: "09/28/2018", haveGift: false, eventNotes: "Don't forget!"),
-                  Event(eventTitle: "Jen's birthday", giftRecipient: "Mom", dateOfEventString: "09/26/2018", haveGift: false, eventNotes: "Don't forget!")]
+    
+    var events = [
+        Event(eventTitle: "Christmas", giftRecipient: "Bella", dateOfEventString: "12/25/2018", haveGift: false, eventNotes: "notes"),
+        Event(eventTitle: "Save your first event!", giftRecipient: "Someone special", dateOfEventString: "12/31/2019", haveGift: false, eventNotes: "Write your gift ideas and such here :)")]
 }

--- a/ForgetMeNot/Model/EventDatabase.swift
+++ b/ForgetMeNot/Model/EventDatabase.swift
@@ -11,5 +11,6 @@ import Foundation
 class EventDatabase {
     var events = [Event(eventTitle: "Christmas", giftRecipient: "Bella", dateOfEventString: "12/25/2018", haveGift: false, eventNotes: "notes"),
                   Event(eventTitle: "Kyubei's 7th Birthday!", giftRecipient: "Kyubei", dateOfEventString: "04/25/2019", haveGift: false, eventNotes: "My baby..."),
-                  Event(eventTitle: "Mom's birthday", giftRecipient: "Mom", dateOfEventString: "05/25/2019", haveGift: false, eventNotes: "Don't forget!")]
+                  Event(eventTitle: "Mom's birthday", giftRecipient: "Mom", dateOfEventString: "05/25/2019", haveGift: false, eventNotes: "Don't forget!"),
+                  Event(eventTitle: "Mom's birthday", giftRecipient: "Mom", dateOfEventString: "03/31/2019", haveGift: false, eventNotes: "Don't forget!")]
 }

--- a/ForgetMeNot/Model/EventDatabase.swift
+++ b/ForgetMeNot/Model/EventDatabase.swift
@@ -12,5 +12,7 @@ class EventDatabase {
     var events = [Event(eventTitle: "Christmas", giftRecipient: "Bella", dateOfEventString: "12/25/2018", haveGift: false, eventNotes: "notes"),
                   Event(eventTitle: "Kyubei's 7th Birthday!", giftRecipient: "Kyubei", dateOfEventString: "04/25/2019", haveGift: false, eventNotes: "My baby..."),
                   Event(eventTitle: "Mom's birthday", giftRecipient: "Mom", dateOfEventString: "05/25/2019", haveGift: false, eventNotes: "Don't forget!"),
-                  Event(eventTitle: "Mom's birthday", giftRecipient: "Mom", dateOfEventString: "03/31/2019", haveGift: false, eventNotes: "Don't forget!")]
+                  Event(eventTitle: "Mom's birthday", giftRecipient: "Mom", dateOfEventString: "03/31/2019", haveGift: false, eventNotes: "Don't forget!"),
+                  Event(eventTitle: "LabsConf", giftRecipient: "Mom", dateOfEventString: "09/28/2018", haveGift: false, eventNotes: "Don't forget!"),
+                  Event(eventTitle: "Jen's birthday", giftRecipient: "Mom", dateOfEventString: "09/26/2018", haveGift: false, eventNotes: "Don't forget!")]
 }


### PR DESCRIPTION
## Reason ✨
Trello Card: [Home: Order Events by Date (soonest first)](https://trello.com/c/rq6TJXA3)

## What I did ✅
- Kind of a lot! 
- We only show events that are in the future. Someday our example events will be in the past, and then they will stop loading. 👍 
- Events are always sorted into soonest -> latest. 
- Only 5 events are ever shown on the homepage.
- The source of events is now conditional: if the user already has a .plist because they've used the app, it'll load from there. If the user has never opened the app, it'll load from our database.
- I made the database have 2 sample events, Christmas and "Save Your First Event!" as an example to a new user. (These could be better, maybe New Year's is a better secular alternative to Christmas?)

## How I did it 🌀
- It's all in the HomeViewController.
- In `populateData()` and `loadEvents()`, events only get appended to our `events` array if the date is in the future (`if event.dateOfEvent > Date()`)
- New function to sort events by date: `sortEvents()`
- New function to limit array to 5: `limitToFiveEvents()`
- New function to combine those two (lol): `sortAndLimitEvents()`
- Updates to the `AddEventViewControllerDelegate` save method. Instead of creating a new row and changing the count of `events`, it adds our new item to `events`, sorts & limits the array, and then reloads the tableView data. 

## How you can test it 🔬
- Run the app!
- If you've run it before, you should see your saved events – but only those that are in the future, and only 5, and they should be sorted.
- If you haven't run it before, you'll see 2 sample events.
- To simulate never having run the app before, you can go to `Hardware > Erase All Content and Settings` in the Simulator
- Add a bunch of new events! You should see them sorted properly by date and limited to the 5 soonest on the home screen.
